### PR TITLE
[videoUtils] Add `ConvertSeqToVideo` and `ConvertVideoToSeq` nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# meshroomVideoUtils
+# mrVideoUtils
 Custom Python nodes dedicated to video creation and manipulation for Meshroom.

--- a/meshroom/videoUtils/ConvertSeqToVideo.py
+++ b/meshroom/videoUtils/ConvertSeqToVideo.py
@@ -1,0 +1,40 @@
+__version__ = "1.0"
+
+import os
+from meshroom.core import desc
+
+
+class ConvertSeqToVideo(desc.CommandLineNode):
+    # use scale to avoid not even width or height ffmpeg error
+    commandLine = 'ffmpeg -y -framerate {framerateValue} -pattern_type glob -i {imagesValue}  -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" {outputVideoValue} '
+    gpu = desc.Level.NONE
+
+    category = "Video Utils"
+    documentation = """
+Create a video from images.
+"""
+
+    inputs = [
+        desc.File(
+            name="images",
+            label="Images",
+            description="List of the images.",
+            value="",
+        ),
+        desc.FloatParam(
+            name="framerate",
+            label="Framerate",
+            description="Video framerate.",
+            value=24.0,
+            range=(10.0, 120.0, 1.0),
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="outputVideo",
+            label="Output Video",
+            description="Output video file.",
+            value=os.path.join("{nodeCacheFolder}", "video.mp4"),
+        ),
+    ]

--- a/meshroom/videoUtils/ConvertSeqToVideo.py
+++ b/meshroom/videoUtils/ConvertSeqToVideo.py
@@ -35,6 +35,6 @@ Create a video from images.
             name="outputVideo",
             label="Output Video",
             description="Output video file.",
-            value=os.path.join("{nodeCacheFolder}", "video.mp4"),
+            value="{nodeCacheFolder}/video.mp4",
         ),
     ]

--- a/meshroom/videoUtils/ConvertVideoToSeq.py
+++ b/meshroom/videoUtils/ConvertVideoToSeq.py
@@ -1,0 +1,57 @@
+__version__ = "1.0"
+
+import os
+import logging
+from pathlib import Path
+from meshroom.core import desc
+
+
+class ConvertVideoToSeq(desc.CommandLineNode):
+    commandLine = "ffmpeg -y -i {videoFileValue}"
+    gpu = desc.Level.NONE
+
+    category = "Video Utils"
+    documentation = """
+Extract frames from a video.
+"""
+
+    inputs = [
+        desc.File(
+            name="videoFile",
+            label="Video File",
+            description="Video file to extract the frames from.",
+            value="",
+        ),
+        desc.StringParam(
+            name="pattern",
+            label="Output Sequence Pattern",
+            description="Filename pattern for the output frames.",
+            value="frame_%04d.png",
+        ),
+    ]
+
+    outputs=[
+        desc.File(
+            name="outputFolder",
+            label="Output Folder",
+            description="Folder where to save the frames.",
+            value=lambda attr: os.path.join("{nodeCacheFolder}", "frames"),
+        ),
+    ]
+
+    def processChunk(self, chunk):
+        if not os.path.exists(chunk.node.videoFile.value):
+            logging.warning('Input video file does not exist: "{}"'.format(chunk.node.videoFile.value))
+            return
+        folder = chunk.node.outputFolder.value
+        logging.warning('Convert video to seq folder: {}'.format(folder))
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+        desc.CommandLineNode.processChunk(self, chunk)
+
+    def buildCommandLine(self, chunk):
+        outputFolder = Path(chunk.node.attribute("outputFolder").value)
+        filePattern = chunk.node.attribute("pattern").value
+
+        suffix = f" {os.path.join(outputFolder,filePattern)}"
+        return desc.CommandLineNode.buildCommandLine(self, chunk) + suffix

--- a/meshroom/videoUtils/ConvertVideoToSeq.py
+++ b/meshroom/videoUtils/ConvertVideoToSeq.py
@@ -7,7 +7,7 @@ from meshroom.core import desc
 
 
 class ConvertVideoToSeq(desc.CommandLineNode):
-    commandLine = "ffmpeg -y -i {videoFileValue}"
+    commandLine = "ffmpeg -y -i {videoFileValue} {outputFolderValue}/{patternValue}"
     gpu = desc.Level.NONE
 
     category = "Video Utils"
@@ -35,23 +35,21 @@ Extract frames from a video.
             name="outputFolder",
             label="Output Folder",
             description="Folder where to save the frames.",
-            value=lambda attr: os.path.join("{nodeCacheFolder}", "frames"),
+            value="{nodeCacheFolder}/frames",
+        ),
+        desc.File(
+            name="outputSequence",
+            label="Output Sequence",
+            description="Output image sequence.",
+            value="{nodeCacheFolder}/frames/*",
+            semantic="sequence",
+            group="",
         ),
     ]
 
     def processChunk(self, chunk):
-        if not os.path.exists(chunk.node.videoFile.value):
-            logging.warning('Input video file does not exist: "{}"'.format(chunk.node.videoFile.value))
-            return
         folder = chunk.node.outputFolder.value
         logging.warning('Convert video to seq folder: {}'.format(folder))
         if not os.path.exists(folder):
             os.makedirs(folder)
         desc.CommandLineNode.processChunk(self, chunk)
-
-    def buildCommandLine(self, chunk):
-        outputFolder = Path(chunk.node.attribute("outputFolder").value)
-        filePattern = chunk.node.attribute("pattern").value
-
-        suffix = f" {os.path.join(outputFolder,filePattern)}"
-        return desc.CommandLineNode.buildCommandLine(self, chunk) + suffix


### PR DESCRIPTION
This PR adds two nodes, "ConvertSeqToVideo" and "ConvertVideoToSeq", that handle the direct conversion from sequences to videos and from videos to sequences, without any compression or resizing options.